### PR TITLE
Cleanup and stuff

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,12 +3,17 @@ plugins {
 	id 'maven-publish'
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
-
 archivesBaseName = project.archives_base_name
-version = project.mod_version
+version = "${project.mod_version}+${getMCVersionString()}"
 group = project.maven_group
+
+def getMCVersionString() {
+	if (project.minecraft_version.matches("\\d\\dw\\d\\d[a-z]")) {
+		return project.minecraft_version
+	}
+	int lastDot = project.minecraft_version.lastIndexOf('.')
+	return project.minecraft_version.substring(0, lastDot)
+}
 
 minecraft {
 }
@@ -19,7 +24,7 @@ dependencies {
 	mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
 	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 
-	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_api_version}"
+	modImplementation fabricApi.module('fabric-resource-loader-v0', project.fabric_api_version)
 }
 
 processResources {
@@ -42,12 +47,11 @@ tasks.withType(JavaCompile) {
 	options.encoding = "UTF-8"
 }
 
-// Loom will automatically attach sourcesJar to a RemapSourcesJar task and to the "build" task
-// if it is present.
-// If you remove this task, sources will not be generated.
-task sourcesJar(type: Jar, dependsOn: classes) {
-	classifier = "sources"
-	from sourceSets.main.allSource
+java {
+	sourceCompatibility = JavaVersion.VERSION_1_8
+	targetCompatibility = JavaVersion.VERSION_1_8
+
+	withSourcesJar()
 }
 
 jar {

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,4 +11,4 @@ maven_group         = io.github.queerbric.pride
 archives_base_name  = pride
 
 #Dependencies
-fabric_api_version  = 0.25.1+build.416-1.16
+fabric_api_version  = 0.30.0+1.16

--- a/src/main/java/io/github/queerbric/pride/PrideClient.java
+++ b/src/main/java/io/github/queerbric/pride/PrideClient.java
@@ -10,7 +10,7 @@ public class PrideClient implements ClientModInitializer {
 	public void onInitializeClient() {
 		MinecraftClient.getInstance().execute(() -> {
 			PrideLoader.firstLoad();
-			((ReloadableResourceManager) MinecraftClient.getInstance().getResourceManager()).registerListener(new PrideLoader());		
+			((ReloadableResourceManager) MinecraftClient.getInstance().getResourceManager()).registerListener(new PrideLoader());
 		});
 	}
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -24,6 +24,6 @@
   ],
   "depends": {
     "fabricloader": ">=0.11.1",
-    "fabric": "*"
+    "fabric-resource-loader-v0": "*"
   }
 }


### PR DESCRIPTION
Cleaned up a little bit the build.gradle with something to differentiate versions based on the MC version.

Only depend (and import) the fabric resource loader module, would conflict with mods only depending on a few Fabric API modules.

Removed 2 trailing tabs in a file.

Future goal is to allow a new branch for 1.17 as it requires changes to the rendering system.