### PR TITLE
Add ModMenu library badge

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -21,5 +21,10 @@
     "minecraft": ">=1.17-alpha.21.3.a",
     "fabricloader": ">=0.11.1",
     "fabric-resource-loader-v0": "*"
+  },
+  "custom": {
+    "modmenu": {
+      "badges": [ "library" ]
+    }
   }
 }


### PR DESCRIPTION
Adds a library badge in [ModMenu](https://github.com/TerraformersMC/ModMenu/wiki/API#badges).