### PR TITLE
Port to 1.8.9 (legacyfabric)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,7 @@ dependencies {
 		exclude module: "legacy-fabric-entity-events-v1"
 	}
 
-	modImplementation include("com.github.moehreag:search-in-resources:1.0.1")
+	modImplementation include("com.github.moehreag:search-in-resources:5691f636b4")
 
 	implementation include('it.unimi.dsi:fastutil:8.5.8') // 1.8.9 does not use fastutil by default
 	implementation('org.apache.logging.log4j:log4j-core:2.19.0')

--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ dependencies {
 		exclude module: "legacy-fabric-entity-events-v1"
 	}
 
-	modImplementation include("com.github.moehreag:search-in-resources:5691f636b4")
+	modImplementation include("com.github.moehreag:search-in-resources:1.0.2")
 
 	implementation include('it.unimi.dsi:fastutil:8.5.8') // 1.8.9 does not use fastutil by default
 	implementation('org.apache.logging.log4j:log4j-core:2.19.0')

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ version = "${project.mod_version}+${getMCVersionString()}"
 group = project.maven_group
 
 // This field defines the Java version your mod target.
-def targetJavaVersion = 17
+def targetJavaVersion = 8
 
 boolean isMCVersionNonRelease() {
 	return project.minecraft_version.matches('^\\d\\dw\\d\\d[a-z]$')
@@ -26,14 +26,34 @@ String getMCVersionString() {
 	return version[0] + '.' + version[1]
 }
 
+repositories {
+	maven {
+		name = "legacy-fabric"
+		url = "https://maven.legacyfabric.net"
+	}
+	maven { url 'https://jitpack.io' }
+	mavenCentral()
+}
+
+loom {
+	setIntermediaryUrl('https://maven.legacyfabric.net/net/fabricmc/intermediary/%1$s/intermediary-%1$s-v2.jar')
+}
+
 dependencies {
 	minecraft "com.mojang:minecraft:${project.minecraft_version}"
-	mappings(loom.layered {
-		addLayer(quiltMappings.mappings("org.quiltmc:quilt-mappings:${minecraft_version}+build.${quilt_mappings}:v2"))
-	})
+	mappings "net.legacyfabric:yarn:${project.minecraft_version}+build.${project.yarn_mappings}:v2"
 	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 
-	modImplementation fabricApi.module('fabric-resource-loader-v0', project.fabric_api_version)
+	// Fabric API provides hooks for events, item registration, and more. As most mods will need this, it's included by default.
+	// If you know for a fact you don't, it's not required and can be safely removed.
+	modImplementation ("net.legacyfabric.legacy-fabric-api:legacy-fabric-api:${fabric_api_version}") {
+		exclude module: "legacy-fabric-entity-events-v1"
+	}
+
+	modImplementation include("com.github.moehreag:search-in-resources:1.0.1")
+
+	implementation include('it.unimi.dsi:fastutil:8.5.8') // 1.8.9 does not use fastutil by default
+	implementation('org.apache.logging.log4j:log4j-core:2.19.0')
 }
 
 java {

--- a/build.gradle
+++ b/build.gradle
@@ -44,8 +44,6 @@ dependencies {
 	mappings "net.legacyfabric:yarn:${project.minecraft_version}+build.${project.yarn_mappings}:v2"
 	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 
-	// Fabric API provides hooks for events, item registration, and more. As most mods will need this, it's included by default.
-	// If you know for a fact you don't, it's not required and can be safely removed.
 	modImplementation ("net.legacyfabric.legacy-fabric-api:legacy-fabric-api:${fabric_api_version}") {
 		exclude module: "legacy-fabric-entity-events-v1"
 	}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,9 @@
 org.gradle.jvmargs  = -Xmx1G
 
 #Fabric properties
-minecraft_version   = 1.19
-quilt_mappings      = 1
-loader_version      = 0.12.12
+minecraft_version   = 1.8.9
+yarn_mappings       = 412
+loader_version      = 0.14.9
 
 #Mod properties
 mod_version         = 1.2.0
@@ -11,4 +11,4 @@ maven_group         = io.github.queerbric
 archives_base_name  = pridelib
 
 #Dependencies
-fabric_api_version  = 0.41.0+1.17
+fabric_api_version  = 1.8.0+1.8.9

--- a/src/main/java/io/github/queerbric/pride/PrideClient.java
+++ b/src/main/java/io/github/queerbric/pride/PrideClient.java
@@ -1,12 +1,11 @@
 package io.github.queerbric.pride;
 
 import net.fabricmc.api.ClientModInitializer;
-import net.fabricmc.fabric.api.resource.ResourceManagerHelper;
-import net.minecraft.resource.ResourceType;
+import net.legacyfabric.fabric.api.resource.ResourceManagerHelper;
 
 public class PrideClient implements ClientModInitializer {
 	@Override
 	public void onInitializeClient() {
-		ResourceManagerHelper.get(ResourceType.CLIENT_RESOURCES).registerReloadListener(new PrideLoader());
+		ResourceManagerHelper.getInstance().registerReloadListener(new PrideLoader());
 	}
 }

--- a/src/main/java/io/github/queerbric/pride/PrideFlag.java
+++ b/src/main/java/io/github/queerbric/pride/PrideFlag.java
@@ -3,7 +3,6 @@ package io.github.queerbric.pride;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntList;
 import it.unimi.dsi.fastutil.ints.IntLists;
-import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.util.Identifier;
 
 /**
@@ -20,7 +19,7 @@ public class PrideFlag {
 		if (props.shape == null) {
 			this.shapeId = new Identifier("pride", "horizontal_stripes");
 		} else {
-			this.shapeId = props.shape.contains(":") ? Identifier.tryParse(props.shape) : new Identifier("pride", props.shape);
+			this.shapeId = parseIdentifier(props.shape);
 		}
 
 		this.shape = PrideFlagShapes.get(this.shapeId);
@@ -28,8 +27,8 @@ public class PrideFlag {
 			throw new IllegalArgumentException("Unknown pride flag shape " + this.shapeId);
 		}
 
-		var colorsTmp = new IntArrayList(props.colors.length);
-		for (var color : props.colors) {
+		IntArrayList colorsTmp = new IntArrayList(props.colors.length);
+		for (String color : props.colors) {
 			colorsTmp.add(Integer.parseInt(color.substring(1), 16) | 0xFF000000);
 		}
 		this.colors = IntLists.unmodifiable(colorsTmp);
@@ -54,14 +53,21 @@ public class PrideFlag {
 	/**
 	 * Renders this flag at the specified coordinates and with the specified dimensions.
 	 *
-	 * @param matrices the matrix stack
 	 * @param x the X-coordinate to render to
 	 * @param y the Y-coordinate to render to
 	 * @param width the render width of the flag
 	 * @param height the render height of the flag
 	 */
-	public void render(MatrixStack matrices, float x, float y, float width, float height) {
-		this.shape.render(this.colors, matrices, x, y, width, height);
+	public void render(float x, float y, float width, float height) {
+		this.shape.render(this.colors, x, y, width, height);
+	}
+
+	private Identifier parseIdentifier(String s){
+		if(s.contains(":")){
+			String[] array = s.split(":",1);
+			return new Identifier(array[0], array[1]);
+		}
+		return new Identifier("pride", s);
 	}
 
 	static class Properties {

--- a/src/main/java/io/github/queerbric/pride/PrideFlagShape.java
+++ b/src/main/java/io/github/queerbric/pride/PrideFlagShape.java
@@ -1,8 +1,7 @@
 package io.github.queerbric.pride;
 
 import it.unimi.dsi.fastutil.ints.IntList;
-import net.minecraft.client.util.math.MatrixStack;
 
 public interface PrideFlagShape {
-	void render(IntList colors, MatrixStack matrices, float x, float y, float width, float height);
+	void render(IntList colors, float x, float y, float width, float height);
 }

--- a/src/main/java/io/github/queerbric/pride/PrideFlagShapes.java
+++ b/src/main/java/io/github/queerbric/pride/PrideFlagShapes.java
@@ -1,15 +1,13 @@
 package io.github.queerbric.pride;
 
-import com.mojang.blaze3d.systems.RenderSystem;
-import com.mojang.blaze3d.vertex.BufferBuilder;
-import com.mojang.blaze3d.vertex.Tessellator;
-import com.mojang.blaze3d.vertex.VertexFormat;
-import com.mojang.blaze3d.vertex.VertexFormats;
+import com.mojang.blaze3d.platform.GlStateManager;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
+import net.minecraft.client.render.BufferBuilder;
+import net.minecraft.client.render.Tessellator;
+import net.minecraft.client.render.VertexFormats;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.math.MathHelper;
-import net.minecraft.util.math.Matrix4f;
 
 import java.util.Map;
 
@@ -29,67 +27,64 @@ public class PrideFlagShapes {
 
 	static {
 		PrideFlagShape horizStripes;
-		register(new Identifier("pride", "horizontal_stripes"), horizStripes = (colors, matrices, x, y, w, h) -> {
+		register(new Identifier("pride", "horizontal_stripes"), horizStripes = (colors, x, y, w, h) -> {
 			float sh = h / colors.size();
-			RenderSystem.disableTexture();
-			Matrix4f mat = matrices.peek().getPosition();
+			GlStateManager.disableTexture();
 			Tessellator t = Tessellator.getInstance();
-			BufferBuilder bb = t.getBufferBuilder();
-			bb.begin(VertexFormat.DrawMode.QUADS, VertexFormats.POSITION_COLOR);
+			BufferBuilder bb = t.getBuffer();
+			bb.begin(7, VertexFormats.POSITION_COLOR);
 			for (int i = 0; i < colors.size(); i++) {
 				int color = colors.getInt(i);
 				float r = ((color >> 16) & 0xFF) / 255f;
 				float g = ((color >> 8) & 0xFF) / 255f;
-				float b = ((color >> 0) & 0xFF) / 255f;
-				bb.vertex(mat, x, y + sh, 0).color(r, g, b, 1).next();
-				bb.vertex(mat, x + w, y + sh, 0).color(r, g, b, 1).next();
-				bb.vertex(mat, x + w, y, 0).color(r, g, b, 1).next();
-				bb.vertex(mat, x, y, 0).color(r, g, b, 1).next();
+				float b = ((color) & 0xFF) / 255f;
+				bb.vertex(x, y + sh, 0).color(r, g, b, 1).next();
+				bb.vertex(x + w, y + sh, 0).color(r, g, b, 1).next();
+				bb.vertex(x + w, y, 0).color(r, g, b, 1).next();
+				bb.vertex(x, y, 0).color(r, g, b, 1).next();
 				y += sh;
 			}
 			t.draw();
 			// Mojang when will you use your state manager system to add fast pushAttrib/popAttrib
-			RenderSystem.enableTexture();
+			GlStateManager.enableTexture();
 		});
-		register(new Identifier("pride", "vertical_stripes"), (colors, matrices, x, y, w, h) -> {
+		register(new Identifier("pride", "vertical_stripes"), (colors, x, y, w, h) -> {
 			float sw = w / colors.size();
-			RenderSystem.disableTexture();
-			Matrix4f mat = matrices.peek().getPosition();
+			GlStateManager.disableTexture();
 			Tessellator t = Tessellator.getInstance();
-			BufferBuilder bb = t.getBufferBuilder();
-			bb.begin(VertexFormat.DrawMode.QUADS, VertexFormats.POSITION_COLOR);
+			BufferBuilder bb = t.getBuffer();
+			bb.begin(7, VertexFormats.POSITION_COLOR);
 			for (int i = 0; i < colors.size(); i++) {
 				int color = colors.getInt(i);
 				float r = ((color >> 16) & 0xFF) / 255f;
 				float g = ((color >> 8) & 0xFF) / 255f;
-				float b = ((color >> 0) & 0xFF) / 255f;
-				bb.vertex(mat, x, y + h, 0).color(r, g, b, 1).next();
-				bb.vertex(mat, x + sw, y + h, 0).color(r, g, b, 1).next();
-				bb.vertex(mat, x + sw, y, 0).color(r, g, b, 1).next();
-				bb.vertex(mat, x, y, 0).color(r, g, b, 1).next();
+				float b = ((color) & 0xFF) / 255f;
+				bb.vertex(x, y + h, 0).color(r, g, b, 1).next();
+				bb.vertex(x + sw, y + h, 0).color(r, g, b, 1).next();
+				bb.vertex(x + sw, y, 0).color(r, g, b, 1).next();
+				bb.vertex(x, y, 0).color(r, g, b, 1).next();
 				x += sw;
 			}
 			t.draw();
-			RenderSystem.enableTexture();
+			GlStateManager.enableTexture();
 		});
-		register(new Identifier("pride", "circle"), (colors, matrices, x, y, w, h) -> {
-			RenderSystem.disableTexture();
-			Matrix4f mat = matrices.peek().getPosition();
+		register(new Identifier("pride", "circle"), (colors, x, y, w, h) -> {
+			GlStateManager.disableTexture();
 			Tessellator tess = Tessellator.getInstance();
-			BufferBuilder bb = tess.getBufferBuilder();
+			BufferBuilder bb = tess.getBuffer();
 			{
 				int color = colors.getInt(0);
 				float r = ((color >> 16) & 0xFF) / 255f;
 				float g = ((color >> 8) & 0xFF) / 255f;
-				float b = ((color >> 0) & 0xFF) / 255f;
-				bb.begin(VertexFormat.DrawMode.QUADS, VertexFormats.POSITION_COLOR);
-				bb.vertex(mat, x, y + h, 0).color(r, g, b, 1).next();
-				bb.vertex(mat, x + w, y + h, 0).color(r, g, b, 1).next();
-				bb.vertex(mat, x + w, y, 0).color(r, g, b, 1).next();
-				bb.vertex(mat, x, y, 0).color(r, g, b, 1).next();
+				float b = ((color) & 0xFF) / 255f;
+				bb.begin(7, VertexFormats.POSITION_COLOR);
+				bb.vertex(x, y + h, 0).color(r, g, b, 1).next();
+				bb.vertex(x + w, y + h, 0).color(r, g, b, 1).next();
+				bb.vertex(x + w, y, 0).color(r, g, b, 1).next();
+				bb.vertex(x, y, 0).color(r, g, b, 1).next();
 				tess.draw();
 			}
-			bb.begin(VertexFormat.DrawMode.TRIANGLE_FAN, VertexFormats.POSITION_COLOR);
+			bb.begin(6, VertexFormats.POSITION_COLOR); // Seems like the int-pendant to TRIANGLE_FAN is 6.
 			float br = Math.min(w, h) * 0.3f;
 			float cx = x + (w / 2);
 			float cy = y + (h / 2);
@@ -98,38 +93,37 @@ public class PrideFlagShapes {
 				int color = (p == 0 ? colors.getInt(1) : colors.getInt(0));
 				float r = ((color >> 16) & 0xFF) / 255f;
 				float g = ((color >> 8) & 0xFF) / 255f;
-				float b = ((color >> 0) & 0xFF) / 255f;
-				bb.vertex(mat, cx, cy, 0).color(r, g, b, 1).next();
+				float b = ((color) & 0xFF) / 255f;
+				bb.vertex(cx, cy, 0).color(r, g, b, 1).next();
 				for (int i = 0; i < 65; i++) {
 					float t = (i / 64f);
 					final float TAU = (float) (Math.PI * 2);
-					bb.vertex(mat, cx + (MathHelper.sin(t * TAU) * rd), cy + (MathHelper.cos(t * TAU) * rd), 0).color(r, g, b, 1).next();
+					bb.vertex(cx + (MathHelper.sin(t * TAU) * rd), cy + (MathHelper.cos(t * TAU) * rd), 0).color(r, g, b, 1).next();
 				}
 			}
 			tess.draw();
-			RenderSystem.enableTexture();
+			GlStateManager.enableTexture();
 		});
-		register(new Identifier("pride", "arrow"), (colors, matrices, x, y, w, h) -> {
+		register(new Identifier("pride", "arrow"), (colors, x, y, w, h) -> {
 			float s = Math.min(w, h) / 2;
 			float cy = y + (h / 2);
-			horizStripes.render(colors.subList(1, colors.size()), matrices, x, y, w, h);
-			RenderSystem.disableTexture();
-			Matrix4f mat = matrices.peek().getPosition();
+			horizStripes.render(colors.subList(1, colors.size()), x, y, w, h);
+			GlStateManager.disableTexture();
 			Tessellator t = Tessellator.getInstance();
-			BufferBuilder bb = t.getBufferBuilder();
-			bb.begin(VertexFormat.DrawMode.TRIANGLES, VertexFormats.POSITION_COLOR);
+			BufferBuilder bb = t.getBuffer();
+			bb.begin(4, VertexFormats.POSITION_COLOR); // Int-pendant to TRIANGLE is 4.
 			int color = colors.getInt(0);
 			float r = ((color >> 16) & 0xFF) / 255f;
 			float g = ((color >> 8) & 0xFF) / 255f;
-			float b = ((color >> 0) & 0xFF) / 255f;
-			bb.vertex(mat, x, cy + s, 0).color(r, g, b, 1).next();
+			float b = ((color) & 0xFF) / 255f;
+			bb.vertex(x, cy + s, 0).color(r, g, b, 1).next();
 			// yes, 1.5. the demisexual flag triangle appears to not be equilateral?
-			bb.vertex(mat, x + (s * 1.5f), cy, 0).color(r, g, b, 1).next();
-			bb.vertex(mat, x, cy - s, 0).color(r, g, b, 1).next();
+			bb.vertex(x + (s * 1.5f), cy, 0).color(r, g, b, 1).next();
+			bb.vertex(x, cy - s, 0).color(r, g, b, 1).next();
 			t.draw();
-			RenderSystem.enableTexture();
+			GlStateManager.enableTexture();
 		});
-		var progressBg = new IntArrayList(new int[]{
+		IntArrayList progressBg = new IntArrayList(new int[]{
 				0xD40606,
 				0xEE9C00,
 				0xE3FF00,
@@ -137,15 +131,14 @@ public class PrideFlagShapes {
 				0x001A98,
 				0x760089,
 		});
-		register(new Identifier("pride", "progress"), (colors, matrices, x, y, w, h) -> {
+		register(new Identifier("pride", "progress"), (colors, x, y, w, h) -> {
 			float hm = Math.min(w, h) / 2;
 			float cy = y + (h / 2);
-			Matrix4f mat = matrices.peek().getPosition();
 			Tessellator t = Tessellator.getInstance();
-			BufferBuilder bb = t.getBufferBuilder();
-			horizStripes.render(progressBg, matrices, x, y, w, h);
-			RenderSystem.disableTexture();
-			bb.begin(VertexFormat.DrawMode.TRIANGLES, VertexFormats.POSITION_COLOR);
+			BufferBuilder bb = t.getBuffer();
+			horizStripes.render(progressBg, x, y, w, h);
+			GlStateManager.disableTexture();
+			bb.begin(4, VertexFormats.POSITION_COLOR);
 			int[] triangleColors = {
 					0x000000,
 					0x603813,
@@ -157,14 +150,14 @@ public class PrideFlagShapes {
 			for (int color : triangleColors) {
 				float r = ((color >> 16) & 0xFF) / 255f;
 				float g = ((color >> 8) & 0xFF) / 255f;
-				float b = ((color >> 0) & 0xFF) / 255f;
-				bb.vertex(mat, x, cy + s, 0).color(r, g, b, 1).next();
-				bb.vertex(mat, x + (s * 1.1f), cy, 0).color(r, g, b, 1).next();
-				bb.vertex(mat, x, cy - s, 0).color(r, g, b, 1).next();
+				float b = ((color) & 0xFF) / 255f;
+				bb.vertex(x, cy + s, 0).color(r, g, b, 1).next();
+				bb.vertex(x + (s * 1.1f), cy, 0).color(r, g, b, 1).next();
+				bb.vertex(x, cy - s, 0).color(r, g, b, 1).next();
 				s -= hm / 6;
 			}
 			t.draw();
-			RenderSystem.enableTexture();
+			GlStateManager.enableTexture();
 		});
 	}
 }

--- a/src/main/java/io/github/queerbric/pride/PrideFlags.java
+++ b/src/main/java/io/github/queerbric/pride/PrideFlags.java
@@ -16,8 +16,8 @@ public class PrideFlags {
 
 	protected static void setFlags(List<PrideFlag> flags) {
 		PrideFlags.flags = Collections.unmodifiableList(flags);
-		var flagsById = new Object2ObjectOpenHashMap<String, PrideFlag>(flags.size());
-		for (var flag : flags) {
+		Object2ObjectOpenHashMap<String, PrideFlag> flagsById = new Object2ObjectOpenHashMap<String, PrideFlag>(flags.size());
+		for (PrideFlag flag : flags) {
 			flagsById.put(flag.getId(), flag);
 		}
 		PrideFlags.flagsById = Collections.unmodifiableMap(flagsById);

--- a/src/main/java/io/github/queerbric/pride/PrideLoader.java
+++ b/src/main/java/io/github/queerbric/pride/PrideLoader.java
@@ -1,31 +1,34 @@
 package io.github.queerbric.pride;
 
 import com.google.gson.Gson;
-import net.fabricmc.fabric.api.resource.SimpleResourceReloadListener;
+import io.github.moehreag.searchInResources.SearchableResourceManager;
 import net.fabricmc.loader.api.FabricLoader;
+import net.legacyfabric.fabric.api.resource.IdentifiableResourceReloadListener;
+import net.legacyfabric.fabric.api.util.Identifier;
 import net.minecraft.resource.Resource;
 import net.minecraft.resource.ResourceManager;
-import net.minecraft.util.Identifier;
-import net.minecraft.util.profiler.Profiler;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.io.File;
 import java.io.FileReader;
+import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executor;
 import java.util.regex.Pattern;
 
-public class PrideLoader implements SimpleResourceReloadListener<List<PrideFlag>> {
+public class PrideLoader implements IdentifiableResourceReloadListener {
 	private static final Identifier ID = new Identifier("pride", "flags");
 	private static final Logger LOGGER = LogManager.getLogger("pride");
 	private static final Gson GSON = new Gson();
 	private static final Pattern HEX_COLOR_PATTERN = Pattern.compile("^#[0-9a-fA-F]{6}$");
+
+	@Override
+	public void reload(ResourceManager resourceManager) {
+		applyFlags(loadFlags(resourceManager));
+	}
 
 	static class Config {
 		String[] flags;
@@ -36,29 +39,19 @@ public class PrideLoader implements SimpleResourceReloadListener<List<PrideFlag>
 		return ID;
 	}
 
-	@Override
-	public CompletableFuture<List<PrideFlag>> load(ResourceManager manager, Profiler profiler, Executor executor) {
-		return CompletableFuture.supplyAsync(() -> loadFlags(manager));
-	}
-
-	@Override
-	public CompletableFuture<Void> apply(List<PrideFlag> list, ResourceManager manager, Profiler profiler, Executor executor) {
-		return CompletableFuture.runAsync(() -> applyFlags(list));
-	}
-
 	public static List<PrideFlag> loadFlags(ResourceManager manager) {
-		var flags = new ArrayList<PrideFlag>();
+		List<PrideFlag> flags = new ArrayList<>();
 
 		outer:
-		for (var entry : manager.findResources("flags", path -> path.getPath().endsWith(".json")).entrySet()) {
-			Identifier id = entry.getKey();
+		for (Resource entry : ((SearchableResourceManager) manager)
+				.findResources("flags", path -> path.getPath().endsWith(".json")).values()){
+			net.minecraft.util.Identifier id = entry.getId();
 			String[] parts = id.getPath().split("/");
 			String name = parts[parts.length - 1];
 			name = name.substring(0, name.length() - 5);
 
-			try (var reader = new InputStreamReader(entry.getValue().open())) {
+			try (InputStreamReader reader = new InputStreamReader(entry.getInputStream())) {
 				PrideFlag.Properties builder = GSON.fromJson(reader, PrideFlag.Properties.class);
-
 				for (String color : builder.colors) {
 					if (!HEX_COLOR_PATTERN.matcher(color).matches()) {
 						LOGGER.warn("[pride] Malformed flag data for flag " + name + ", " + color
@@ -67,16 +60,16 @@ public class PrideLoader implements SimpleResourceReloadListener<List<PrideFlag>
 					}
 				}
 
-				var flag = new PrideFlag(name, builder);
+				PrideFlag flag = new PrideFlag(name, builder);
 				flags.add(flag);
 			} catch (Exception e) {
 				LOGGER.warn("[pride] Malformed flag data for flag " + name, e);
 			}
 		}
 
-		var prideFile = new File(FabricLoader.getInstance().getConfigDir().toFile(), "pride.json");
+		File prideFile = new File(FabricLoader.getInstance().getConfigDir().toFile(), "pride.json");
 		if (prideFile.exists()) {
-			try (var reader = new FileReader(prideFile)) {
+			try (FileReader reader = new FileReader(prideFile)) {
 				Config config = GSON.fromJson(reader, Config.class);
 
 				if (config.flags != null) {
@@ -87,11 +80,11 @@ public class PrideLoader implements SimpleResourceReloadListener<List<PrideFlag>
 				LOGGER.warn("[pride] Malformed flag data for pride.json config");
 			}
 		} else {
-			var id = new Identifier("pride", "flags.json");
+			net.minecraft.util.Identifier id = new net.minecraft.util.Identifier("pride", "flags.json");
 
-			Optional<Resource> resource = manager.method_14486(id);
-			if (resource.isPresent()) {
-				try (var reader = new InputStreamReader(resource.get().open())) {
+			try {
+				Resource resource = manager.getResource(id);
+				try (InputStreamReader reader = new InputStreamReader(resource.getInputStream())) {
 					Config config = GSON.fromJson(reader, Config.class);
 
 					if (config.flags != null) {
@@ -101,13 +94,14 @@ public class PrideLoader implements SimpleResourceReloadListener<List<PrideFlag>
 				} catch (Exception e) {
 					LOGGER.warn("[pride] Malformed flag data for flags.json", e);
 				}
-			}
+
+			} catch (IOException ignored){}
 		}
 
 		return flags;
 	}
 
-	private static void applyFlags(List<PrideFlag> flags) {
+	private void applyFlags(List<PrideFlag> flags) {
 		PrideFlags.setFlags(flags);
 	}
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -20,10 +20,11 @@
       "io.github.queerbric.pride.PrideClient"
     ]
   },
+  "mixins": [],
   "depends": {
-    "minecraft": ">=1.19",
+    "minecraft": "1.8.9",
     "fabricloader": ">=0.12.12",
-    "fabric-resource-loader-v0": "*"
+    "legacy-fabric-resource-loader-v1": "*"
   },
   "custom": {
     "modmenu": {


### PR DESCRIPTION
somehow there are still people using this version, so they might as well get some of the queer.

Explanation of the new dependencies:
- fastutil needed to be added since Minecraft didn't already use back then.
- [search-in-resources](https://github.com/moehreag/search-in-resources) provides a `resourceManager.findResources(...)` like syntax for this version, which also didn't exist on 1.8.9.
- runtime dependency on log4j, otherwise logging breaks for this version of Minecraft in the dev env.

Other changes:
- replacement of `var` keywords, because Java 8 doesn't know them (yet)
- create a small method for Identifier parsing, since that didn't exist in MC's code.

If you consider merging this, maybe create a new branch to point it to in advance.